### PR TITLE
修复AStarFindPath的调用结果不正确或内存访问报错

### DIFF
--- a/libop/algorithm/AStar.hpp
+++ b/libop/algorithm/AStar.hpp
@@ -110,8 +110,8 @@ public:
 				auto it = _openset.find(temp);
 				//如果节点不在开放节点
 				if (it == _openset.end()) {
-
-					temp.parent = (Node*)&(*_closedset.find(curr_node));
+					auto findIter = std::find_if(_closedset.begin(), _closedset.end(), [&](Node it) {return it.pos == curr_node.pos; });
+			        temp.parent = (Node*)&(*findIter);
 					_openset.insert(temp);
 				}
 				else {

--- a/libop/algorithm/AStar.hpp
+++ b/libop/algorithm/AStar.hpp
@@ -110,7 +110,7 @@ public:
 				auto it = _openset.find(temp);
 				//如果节点不在开放节点
 				if (it == _openset.end()) {
-			        temp.parent = (Node*)&(*_closedset.find(curr_node));
+					temp.parent = (Node*)&(*_closedset.find(curr_node));
 					_openset.insert(temp);
 				}
 				else {

--- a/libop/algorithm/AStar.hpp
+++ b/libop/algorithm/AStar.hpp
@@ -43,7 +43,7 @@ public:
 	struct Nodeless
 	{
 		bool operator()(const Node& lhs, const Node& rhs) const {
-			return lhs.pos.x < rhs.pos.y || (lhs.pos.x == rhs.pos.x && lhs.pos.y < rhs.pos.y);
+			return lhs.pos.x < rhs.pos.x || (lhs.pos.x == rhs.pos.x && lhs.pos.y < rhs.pos.y);
 		}
 	};
 	struct Vec2less {
@@ -110,8 +110,7 @@ public:
 				auto it = _openset.find(temp);
 				//如果节点不在开放节点
 				if (it == _openset.end()) {
-					auto findIter = std::find_if(_closedset.begin(), _closedset.end(), [&](Node it) {return it.pos == curr_node.pos; });
-			        temp.parent = (Node*)&(*findIter);
+			        temp.parent = (Node*)&(*_closedset.find(curr_node));
 					_openset.insert(temp);
 				}
 				else {

--- a/libop/com/OpInterface.cpp
+++ b/libop/com/OpInterface.cpp
@@ -302,10 +302,10 @@ STDMETHODIMP OpInterface::GetWindowClass(LONG hwnd, BSTR *retstring)
 {
 	// TODO: 在此添加实现代码
 	wstring s;
+	obj.GetWindowClass(hwnd, s);
 
 	CComBSTR newbstr;
 	newbstr.Append(s.data());
-
 	newbstr.CopyTo(retstring);
 	return S_OK;
 }

--- a/libop/libop.cpp
+++ b/libop/libop.cpp
@@ -223,17 +223,17 @@ void libop::AStarFindPath(long mapWidth, long mapHeight, const wchar_t *disable_
 
 	as.set_map(mapWidth, mapHeight, walls);
 	as.findpath(beginX, beginY, endX, endY, paths);
-	wstring pathstr;
+	path.clear();
 	wchar_t buf[20];
 	for (auto it = paths.rbegin(); it != paths.rend(); ++it)
 	{
 		auto v = *it;
 		wsprintf(buf, L"%d,%d", v.x, v.y);
-		pathstr += buf;
-		pathstr.push_back(L'|');
+		path += buf;
+		path.push_back(L'|');
 	}
-	if (!pathstr.empty())
-		pathstr.pop_back();
+	if (!path.empty())
+		path.pop_back();
 }
 
 void libop::FindNearestPos(const wchar_t *all_pos, long type, long x, long y, std::wstring &ret)


### PR DESCRIPTION
_closedset.find的返回值有可能是end()  （在 curr_node存在父节点时）
此时的 parent 赋值则为野指针
通过 std::find_if 自定义比较函数"规避"野指针

AStarFindPath里面并没有返回给外部，这里是加上了