### PR TITLE
feat: 新增 BindWindowEx 支持显示和输入分离绑定

### DIFF
--- a/include/libop.h
+++ b/include/libop.h
@@ -175,12 +175,15 @@ class OP_API libop {
     // 延时指定范围内随机毫秒,过程中不阻塞UI操作
     void Delays(long mis_min, long mis_max, long *ret);
     //--------------------Background -----------------------
-    // bind window and beign capture screen
+    // 兼容旧接口的单句柄绑定。显示和输入都使用同一个 hwnd。
     void BindWindow(long hwnd, const wchar_t *display, const wchar_t *mouse, const wchar_t *keypad, long mode,
                     long *ret);
+    // 扩展绑定接口。显示截图使用 display_hwnd，鼠标和键盘输入使用 input_hwnd。
+    void BindWindowEx(long display_hwnd, long input_hwnd, const wchar_t *display, const wchar_t *mouse,
+                      const wchar_t *keypad, long mode, long *ret);
     // 解绑窗口
     void UnBindWindow(long *ret);
-    // 获取当前对象已经绑定的窗口句柄. 无绑定返回0
+    // 获取当前对象已经绑定的显示窗口句柄. 无绑定返回0
     void GetBindWindow(long *ret);
     // 判定当前对象是否已绑定窗口.
     void IsBind(long *ret);

--- a/libop/background/opBackground.cpp
+++ b/libop/background/opBackground.cpp
@@ -16,7 +16,8 @@
 #include "./mouse/opMouseDx.h"
 
 opBackground::opBackground()
-    : _hwnd(0), _is_bind(0), _pbkdisplay(nullptr), _bkmouse(new opMouseWin), _keypad(new winkeypad) {
+    : _display_hwnd(0), _input_hwnd(0), _is_bind(0), _pbkdisplay(nullptr), _bkmouse(new opMouseWin),
+      _keypad(new winkeypad) {
     _display_method = std::make_pair<wstring, wstring>(L"screen", L"");
 }
 
@@ -37,13 +38,19 @@ opBackground::~opBackground() {
 
 long opBackground::BindWindow(long hwnd, const wstring &sdisplay, const wstring &smouse, const wstring &skeypad,
                               long mode) {
+    return BindWindowEx(hwnd, hwnd, sdisplay, smouse, skeypad, mode);
+}
+
+long opBackground::BindWindowEx(long display_hwnd, long input_hwnd, const wstring &sdisplay, const wstring &smouse,
+                                const wstring &skeypad, long mode) {
     // step 1.避免重复绑定
     UnBindWindow();
 
-    HWND hWnd = hwnd == 0 ? GetDesktopWindow() : HWND(hwnd);
+    HWND displayWnd = display_hwnd == 0 ? GetDesktopWindow() : HWND(display_hwnd);
+    HWND inputWnd = input_hwnd == 0 ? displayWnd : HWND(input_hwnd);
     // step 2.check hwnd
-    if (!::IsWindow(hWnd)) {
-        setlog("Invalid window handles");
+    if (!::IsWindow(displayWnd) || !::IsWindow(inputWnd)) {
+        setlog("Invalid window handles display=%p input=%p", displayWnd, inputWnd);
         return 0;
     }
 
@@ -114,7 +121,8 @@ long opBackground::BindWindow(long hwnd, const wstring &sdisplay, const wstring 
     // step 4.init
     _mode = mode;
     _display = display;
-    _hwnd = hWnd;
+    _display_hwnd = displayWnd;
+    _input_hwnd = inputWnd;
     set_display_method(L"screen");
 
     // step 5. create instance
@@ -128,7 +136,13 @@ long opBackground::BindWindow(long hwnd, const wstring &sdisplay, const wstring 
         return 0;
     }
     // step 6.try bind
-    if (_pbkdisplay->Bind(hWnd, display) != 1 || _bkmouse->Bind(hWnd, mouse) != 1 || _keypad->Bind(hWnd, keypad) != 1) {
+    const long display_ret = _pbkdisplay->Bind(displayWnd, display);
+    const long mouse_ret = display_ret == 1 ? _bkmouse->Bind(inputWnd, mouse) : 0;
+    const long keypad_ret = (display_ret == 1 && mouse_ret == 1) ? _keypad->Bind(inputWnd, keypad) : 0;
+    if (display_ret != 1 || mouse_ret != 1 || keypad_ret != 1) {
+        setlog(L"BindWindowEx failed. display_hwnd=%p input_hwnd=%p display=%s(%d) ret=%d mouse=%s(%d) ret=%d keypad=%s(%d) ret=%d",
+               displayWnd, inputWnd, sdisplay.c_str(), display, display_ret, smouse.c_str(), mouse, mouse_ret,
+               skeypad.c_str(), keypad, keypad_ret);
         UnBindWindow();
         return 0;
     }
@@ -143,7 +157,8 @@ long opBackground::BindWindow(long hwnd, const wstring &sdisplay, const wstring 
 long opBackground::UnBindWindow() {
     // to do
     // clear ....
-    _hwnd = NULL;
+    _display_hwnd = NULL;
+    _input_hwnd = NULL;
     _is_bind = 0;
     _mode = 0;
 
@@ -167,7 +182,7 @@ long opBackground::UnBindWindow() {
 }
 
 long opBackground::GetBindWindow() {
-    return (long)_hwnd;
+    return (long)_display_hwnd;
 }
 
 long opBackground::IsBind() {

--- a/libop/background/opBackground.h
+++ b/libop/background/opBackground.h
@@ -17,9 +17,14 @@ class opBackground {
     ~opBackground();
 
   public:
+    // 扩展绑定接口。显示截图绑定到 display_hwnd，鼠标和键盘输入绑定到 input_hwnd。
+    virtual long BindWindowEx(long display_hwnd, long input_hwnd, const wstring &sdisplay, const wstring &smouse,
+                              const wstring &skeypad, long mode);
+    // 兼容旧接口的单句柄绑定，内部等价于显示和输入都绑定到同一个 hwnd。
     virtual long BindWindow(long hwnd, const wstring &sdisplay, const wstring &smouse, const wstring &skeypad,
                             long mode);
     virtual long UnBindWindow();
+    // 返回当前绑定的显示窗口句柄。使用 BindWindowEx 时，输入句柄可能不同于这个句柄。
     virtual long GetBindWindow();
     virtual long IsBind();
     // virtual long GetCursorPos(int& x, int& y);
@@ -41,7 +46,8 @@ class opBackground {
     bool requestCapture(int x1, int y1, int w, int h, Image &img);
 
   private:
-    HWND _hwnd;
+    HWND _display_hwnd;
+    HWND _input_hwnd;
     int _is_bind;
     int _display;
     int _mode;

--- a/libop/com/OpInterface.cpp
+++ b/libop/com/OpInterface.cpp
@@ -418,6 +418,12 @@ STDMETHODIMP OpInterface::BindWindow(LONG hwnd, BSTR display, BSTR mouse, BSTR k
     return S_OK;
 }
 
+STDMETHODIMP OpInterface::BindWindowEx(LONG display_hwnd, LONG input_hwnd, BSTR display, BSTR mouse, BSTR keypad,
+                                       LONG mode, LONG *ret) {
+    obj.BindWindowEx(display_hwnd, input_hwnd, display, mouse, keypad, mode, ret);
+    return S_OK;
+}
+
 STDMETHODIMP OpInterface::UnBindWindow(LONG *ret) {
     obj.UnBindWindow(ret);
 

--- a/libop/com/OpInterface.h
+++ b/libop/com/OpInterface.h
@@ -182,8 +182,11 @@ class ATL_NO_VTABLE OpInterface
     // 延时指定范围内随机毫秒,过程中不阻塞UI操作
     STDMETHOD(Delays)(LONG mis_min, LONG mis_max, LONG *ret);
     //--------------------Background -----------------------
-    // bind window and beign capture screen
+    // 兼容旧接口的单句柄绑定。显示和输入都使用同一个 hwnd。
     STDMETHOD(BindWindow)(LONG hwnd, BSTR display, BSTR mouse, BSTR keypad, LONG mode, LONG *ret);
+    // 扩展绑定接口。显示截图使用 display_hwnd，鼠标和键盘输入使用 input_hwnd。
+    STDMETHOD(BindWindowEx)
+    (LONG display_hwnd, LONG input_hwnd, BSTR display, BSTR mouse, BSTR keypad, LONG mode, LONG *ret);
     //
     STDMETHOD(UnBindWindow)(LONG *ret);
     // 获取当前对象已经绑定的窗口句柄. 无绑定返回0

--- a/libop/com/op.idl
+++ b/libop/com/op.idl
@@ -89,6 +89,7 @@ interface IOpInterface : IDispatch
 	[id(101)] HRESULT UnBindWindow([out, retval] LONG* ret);
 	[id(102)] HRESULT GetBindWindow([out, retval] LONG* ret);
 	[id(103)] HRESULT IsBind([out, retval] LONG* ret);
+	[id(104)] HRESULT BindWindowEx([in] LONG display_hwnd, [in] LONG input_hwnd, [in] BSTR display, [in] BSTR mouse, [in] BSTR keypad, [in] LONG mode, [out, retval] LONG* ret);
 	//mouse & ketboard 120-149
 	[id(120)] HRESULT GetCursorPos([out] VARIANT* x, [out] VARIANT* y, [out, retval] LONG* ret);
 	[id(121)] HRESULT MoveR([in] LONG x, [in] LONG y, [out, retval] LONG* ret);

--- a/libop/com/op_i.h
+++ b/libop/com/op_i.h
@@ -355,6 +355,15 @@ EXTERN_C const IID IID_IOpInterface;
         virtual /* [id] */ HRESULT STDMETHODCALLTYPE IsBind( 
             /* [retval][out] */ LONG *ret) = 0;
         
+        virtual /* [id] */ HRESULT STDMETHODCALLTYPE BindWindowEx( 
+            /* [in] */ LONG display_hwnd,
+            /* [in] */ LONG input_hwnd,
+            /* [in] */ BSTR display,
+            /* [in] */ BSTR mouse,
+            /* [in] */ BSTR keypad,
+            /* [in] */ LONG mode,
+            /* [retval][out] */ LONG *ret) = 0;
+        
         virtual /* [id] */ HRESULT STDMETHODCALLTYPE GetCursorPos( 
             /* [out] */ VARIANT *x,
             /* [out] */ VARIANT *y,
@@ -1259,6 +1268,17 @@ EXTERN_C const IID IID_IOpInterface;
             IOpInterface * This,
             /* [retval][out] */ LONG *ret);
         
+        DECLSPEC_XFGVIRT(IOpInterface, BindWindowEx)
+        /* [id] */ HRESULT ( STDMETHODCALLTYPE *BindWindowEx )( 
+            IOpInterface * This,
+            /* [in] */ LONG display_hwnd,
+            /* [in] */ LONG input_hwnd,
+            /* [in] */ BSTR display,
+            /* [in] */ BSTR mouse,
+            /* [in] */ BSTR keypad,
+            /* [in] */ LONG mode,
+            /* [retval][out] */ LONG *ret);
+        
         DECLSPEC_XFGVIRT(IOpInterface, GetCursorPos)
         /* [id] */ HRESULT ( STDMETHODCALLTYPE *GetCursorPos )( 
             IOpInterface * This,
@@ -2086,6 +2106,9 @@ EXTERN_C const IID IID_IOpInterface;
 #define IOpInterface_IsBind(This,ret)	\
     ( (This)->lpVtbl -> IsBind(This,ret) ) 
 
+#define IOpInterface_BindWindowEx(This,display_hwnd,input_hwnd,display,mouse,keypad,mode,ret)	\
+    ( (This)->lpVtbl -> BindWindowEx(This,display_hwnd,input_hwnd,display,mouse,keypad,mode,ret) ) 
+
 #define IOpInterface_GetCursorPos(This,x,y,ret)	\
     ( (This)->lpVtbl -> GetCursorPos(This,x,y,ret) ) 
 
@@ -2328,6 +2351,20 @@ EXTERN_C const IID IID_IOpInterface;
 
 #endif 	/* C style interface */
 
+
+
+/* [id] */ HRESULT STDMETHODCALLTYPE IOpInterface_AddDict_Proxy( 
+    IOpInterface * This,
+    /* [in] */ LONG idx,
+    /* [in] */ BSTR dict_info,
+    /* [retval][out] */ LONG *ret);
+
+
+void __RPC_STUB IOpInterface_AddDict_Stub(
+    IRpcStubBuffer *This,
+    IRpcChannelBuffer *_pRpcChannelBuffer,
+    PRPC_MESSAGE _pRpcMessage,
+    DWORD *_pdwStubPhase);
 
 
 /* [id] */ HRESULT STDMETHODCALLTYPE IOpInterface_SaveDict_Proxy( 

--- a/libop/libop.cpp
+++ b/libop/libop.cpp
@@ -537,9 +537,14 @@ void libop::Delays(long mis_min, long mis_max, long *ret) {
 
 void libop::BindWindow(long hwnd, const wchar_t *display, const wchar_t *mouse, const wchar_t *keypad, long mode,
                        long *ret) {
+    BindWindowEx(hwnd, hwnd, display, mouse, keypad, mode, ret);
+}
+
+void libop::BindWindowEx(long display_hwnd, long input_hwnd, const wchar_t *display, const wchar_t *mouse,
+                         const wchar_t *keypad, long mode, long *ret) {
     if (m_context->bkproc.IsBind())
         m_context->bkproc.UnBindWindow();
-    *ret = m_context->bkproc.BindWindow(hwnd, display, mouse, keypad, mode);
+    *ret = m_context->bkproc.BindWindowEx(display_hwnd, input_hwnd, display, mouse, keypad, mode);
 }
 
 void libop::UnBindWindow(long *ret) {

--- a/libop/libop.h
+++ b/libop/libop.h
@@ -177,12 +177,15 @@ class OP_API libop {
     // 延时指定范围内随机毫秒,过程中不阻塞UI操作
     void Delays(long mis_min, long mis_max, long *ret);
     //--------------------Background -----------------------
-    // bind window and beign capture screen
+    // 兼容旧接口的单句柄绑定。显示和输入都使用同一个 hwnd。
     void BindWindow(long hwnd, const wchar_t *display, const wchar_t *mouse, const wchar_t *keypad, long mode,
                     long *ret);
+    // 扩展绑定接口。显示截图使用 display_hwnd，鼠标和键盘输入使用 input_hwnd。
+    void BindWindowEx(long display_hwnd, long input_hwnd, const wchar_t *display, const wchar_t *mouse,
+                      const wchar_t *keypad, long mode, long *ret);
     // 解绑窗口
     void UnBindWindow(long *ret);
-    // 获取当前对象已经绑定的窗口句柄. 无绑定返回0
+    // 获取当前对象已经绑定的显示窗口句柄. 无绑定返回0
     void GetBindWindow(long *ret);
     // 判定当前对象是否已绑定窗口.
     void IsBind(long *ret);

--- a/tests/mouse_keyboard_test.cpp
+++ b/tests/mouse_keyboard_test.cpp
@@ -6,6 +6,7 @@
 #include <thread>
 
 using namespace std;
+using test_support::ColorPulseWindow;
 using test_support::MouseEventWindow;
 
 namespace {
@@ -41,6 +42,18 @@ struct InputResetGuard {
             SendKeyboardInput(key_vk, KEYEVENTF_KEYUP);
     }
 };
+
+void PumpMessagesFor(int milliseconds) {
+    const auto end = std::chrono::steady_clock::now() + std::chrono::milliseconds(milliseconds);
+    MSG msg = {};
+    while (std::chrono::steady_clock::now() < end) {
+        while (::PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
+            ::TranslateMessage(&msg);
+            ::DispatchMessageW(&msg);
+        }
+        ::Sleep(10);
+    }
+}
 
 } // namespace
 
@@ -265,6 +278,43 @@ TEST(MouseKeyTest, WindowsModeMouseReturnAndWheel) {
     EXPECT_GE(window.right_up, 1);
     EXPECT_GE(window.wheel_count, 2);
     EXPECT_EQ(window.wheel_delta_sum, 0);
+
+    long unbind_ret = 0;
+    op.UnBindWindow(&unbind_ret);
+    EXPECT_EQ(unbind_ret, 1);
+}
+
+TEST(MouseKeyTest, BindWindowExSeparatesDisplayAndInputTargets) {
+    libop op;
+    MouseEventWindow input_window;
+    ColorPulseWindow display_window;
+    ASSERT_TRUE(input_window.Create());
+    ASSERT_TRUE(display_window.Create(false, 240, 180));
+
+    display_window.SetColor(RGB(255, 0, 0));
+    PumpMessagesFor(120);
+
+    long ret = 0;
+    op.BindWindowEx((long)(intptr_t)display_window.hwnd, (long)(intptr_t)input_window.hwnd, L"normal", L"windows",
+                    L"windows", 0, &ret);
+    ASSERT_EQ(ret, 1) << "BindWindowEx should support separate display/input hwnds";
+
+    std::wstring color;
+    op.GetColor(60, 60, color);
+    EXPECT_EQ(color, display_window.CurrentColorHex());
+
+    op.MoveTo(30, 40, &ret);
+    EXPECT_EQ(ret, 1);
+    op.LeftClick(&ret);
+    EXPECT_EQ(ret, 1);
+
+    EXPECT_GE(input_window.move_count, 1);
+    EXPECT_GE(input_window.left_down, 1);
+    EXPECT_GE(input_window.left_up, 1);
+
+    long bind_hwnd = 0;
+    op.GetBindWindow(&bind_hwnd);
+    EXPECT_EQ(bind_hwnd, (long)(intptr_t)display_window.hwnd);
 
     long unbind_ret = 0;
     op.UnBindWindow(&unbind_ret);


### PR DESCRIPTION
## 说明

新增 `BindWindowEx` 接口，用于支持显示窗口和输入窗口分别绑定。

原有 `BindWindow` 保持兼容，内部仍按单句柄方式使用。

## 本次修改

- 新增 `BindWindowEx(display_hwnd, input_hwnd, ...)`
- 显示绑定到 `display_hwnd`
- 鼠标和键盘绑定到 `input_hwnd`
- 同步补充 COM 接口
- 增加双句柄绑定测试

## 适用场景

有些程序的截图窗口和输入窗口不是同一个句柄，单独使用 `BindWindow` 不够，这种情况可以使用 `BindWindowEx`。