### PR TITLE
fix: 修复 keypad 多模式下的键盘输入问题

### DIFF
--- a/libop/background/keypad/winkeypad.cpp
+++ b/libop/background/keypad/winkeypad.cpp
@@ -2,6 +2,7 @@
 #include "winkeypad.h"
 #include "./core/globalVar.h"
 #include "./core/helpfunc.h"
+#include <string>
 
 static uint oem_code(uint key) {
     short code[256] = {0};
@@ -43,6 +44,78 @@ static long normalize_vk_code(long vk_code) {
     return vk_code;
 }
 
+static bool is_alt_vk(long vk_code) {
+    return vk_code == VK_MENU || vk_code == VK_LMENU || vk_code == VK_RMENU;
+}
+
+static bool is_ctrl_vk(long vk_code) {
+    return vk_code == VK_CONTROL || vk_code == VK_LCONTROL || vk_code == VK_RCONTROL;
+}
+
+static bool is_shift_vk(long vk_code) {
+    return vk_code == VK_SHIFT || vk_code == VK_LSHIFT || vk_code == VK_RSHIFT;
+}
+
+static bool is_extended_vk(long vk_code) {
+    switch (vk_code) {
+    case VK_RMENU:
+    case VK_RCONTROL:
+    case VK_INSERT:
+    case VK_DELETE:
+    case VK_HOME:
+    case VK_END:
+    case VK_PRIOR:
+    case VK_NEXT:
+    case VK_LEFT:
+    case VK_RIGHT:
+    case VK_UP:
+    case VK_DOWN:
+    case VK_NUMLOCK:
+    case VK_SNAPSHOT:
+    case VK_DIVIDE:
+    case VK_APPS:
+    case VK_LWIN:
+    case VK_RWIN:
+        return true;
+    default:
+        return false;
+    }
+}
+
+// 按键消息的 lParam 需要带扫描码、扩展键标志和按下/抬起状态。
+static LPARAM build_windows_key_lparam(long vk_code, bool key_up, bool extended, bool alt_context) {
+    DWORD data = 1;
+    const WORD scan_code = static_cast<WORD>(::MapVirtualKey(vk_code, MAPVK_VK_TO_VSC));
+    data |= static_cast<DWORD>(scan_code) << 16;
+    if (extended)
+        data |= 1u << 24;
+    if (alt_context)
+        data |= 1u << 29;
+    if (key_up)
+        data |= 3u << 30;
+    return static_cast<LPARAM>(data);
+}
+
+// 按当前修饰键状态把虚拟键翻译成字符，供 WM_CHAR / WM_SYSCHAR 使用。
+static bool translate_vk_to_text(long vk_code, bool shift_down, bool ctrl_down, bool alt_down, std::wstring &text) {
+    BYTE key_state[256] = {0};
+    if (shift_down)
+        key_state[VK_SHIFT] = 0x80;
+    if (ctrl_down)
+        key_state[VK_CONTROL] = 0x80;
+    if (alt_down)
+        key_state[VK_MENU] = 0x80;
+
+    wchar_t chars[8] = {0};
+    const UINT scan_code = static_cast<UINT>(::MapVirtualKey(vk_code, MAPVK_VK_TO_VSC));
+    const int count = ::ToUnicodeEx(vk_code, scan_code, key_state, chars, 8, 0, ::GetKeyboardLayout(0));
+    if (count <= 0)
+        return false;
+
+    text.assign(chars, chars + count);
+    return true;
+}
+
 winkeypad::winkeypad() : bkkeypad() {
 }
 
@@ -61,6 +134,9 @@ long winkeypad::Bind(HWND hwnd, long mode) {
 long winkeypad::UnBind() {
     _hwnd = NULL;
     _mode = 0;
+    _shift_down = false;
+    _ctrl_down = false;
+    _alt_down = false;
     return 1;
 }
 
@@ -96,53 +172,33 @@ long winkeypad::KeyDown(long vk_code) {
         Input.ki.wVk = 0;
         Input.ki.wScan = MapVirtualKey(vk_code, MAPVK_VK_TO_VSC);
         Input.ki.dwFlags = KEYEVENTF_SCANCODE;
+        // 扫描码模式下，扩展键还需要补扩展键标志。
+        if (is_extended_vk(vk_code))
+            Input.ki.dwFlags |= KEYEVENTF_EXTENDEDKEY;
         ret = ::SendInput(1, &Input, sizeof(INPUT));
         if (ret == 0)
             setlog("op:IN_NORMAL2 erro code:%s", GetLastErrorAsString().c_str());
         break;
     }
     case INPUT_TYPE::IN_WINDOWS: {
-        /*Specification of WM_KEYDOWN :*/
+        // windows 模式下补扩展键标志，并在 Alt 参与时切到系统键消息。
+        const bool extended = is_extended_vk(vk_code);
+        const bool use_system_message = is_alt_vk(vk_code) || _alt_down;
+        const bool alt_context = _alt_down && !is_alt_vk(vk_code);
+        const UINT message = use_system_message ? WM_SYSKEYDOWN : WM_KEYDOWN;
+        const LPARAM lparam = build_windows_key_lparam(vk_code, false, extended, alt_context);
 
-        /*wParam
-
-            Specifies the virtual - key code of the nonsystem key.
-        lParam
-            Specifies the repeat count, scan code, extended - key flag, context code,
-            previous key - state flag,
-            and transition - state flag, as shown in the following table.
-            0 - 15
-            Specifies the repeat count for the current message.The value is
-            the number of times the keystroke is
-            autorepeated as a result of the user holding down the key.If the
-            keystroke is held long enough, multiple messages are sent.However,
-            the repeat count is not cumulative.
-            16 - 23
-            Specifies the scan code.The value depends on the OEM.
-            24
-            Specifies whether the key is an extended key, such as the
-            right - hand ALT and CTRL keys that
-            appear on an enhanced 101 - or 102 - key keyboard.The value
-            is 1 if it is an extended key; otherwise, it is 0.
-            25 - 28
-            Reserved; do not use.
-            29
-            Specifies the context code.The value is always 0 for a WM_KEYDOWN message.
-            30
-            Specifies the previous key state.The value is 1 if the key
-            is down before the message is sent, or it is zero if the key is up.
-            31
-            Specifies the transition state.The value is always zero for a WM_KEYDOWN message.*/
-
-        DWORD dwVKFkeyData;
-        WORD dwScanCode = MapVirtualKey(vk_code, 0);
-        dwVKFkeyData = 1;
-        dwVKFkeyData |= dwScanCode << 16;
-        dwVKFkeyData |= 0 << 24;
-        dwVKFkeyData |= 0 << 29;
-        ret = ::SendMessageTimeout(_hwnd, WM_KEYDOWN, vk_code, dwVKFkeyData, SMTO_BLOCK, 2000, nullptr);
+        ret = ::SendMessageTimeout(_hwnd, message, vk_code, lparam, SMTO_BLOCK, 2000, nullptr);
         if (ret == 0)
             setlog("error code=%d", GetLastError());
+        else {
+            if (is_shift_vk(vk_code))
+                _shift_down = true;
+            else if (is_ctrl_vk(vk_code))
+                _ctrl_down = true;
+            else if (is_alt_vk(vk_code))
+                _alt_down = true;
+        }
         break;
     }
     }
@@ -176,6 +232,9 @@ long winkeypad::KeyUp(long vk_code) {
         Input.ki.wVk = 0;
         Input.ki.wScan = MapVirtualKey(vk_code, MAPVK_VK_TO_VSC);
         Input.ki.dwFlags = KEYEVENTF_SCANCODE | KEYEVENTF_KEYUP;
+        // 抬键时保持和按下阶段一致的扩展键标志。
+        if (is_extended_vk(vk_code))
+            Input.ki.dwFlags |= KEYEVENTF_EXTENDEDKEY;
         ret = ::SendInput(1, &Input, sizeof(INPUT));
         if (ret == 0)
             setlog("op:IN_NORMAL2 erro code:%s", GetLastErrorAsString().c_str());
@@ -183,36 +242,24 @@ long winkeypad::KeyUp(long vk_code) {
     }
 
     case INPUT_TYPE::IN_WINDOWS: {
-        /*Specification of WM_KEYUP
-        wParam
-            Specifies the virtual - key code of the nonsystem key.
-            lParam
-            Specifies the repeat count, scan code, extended - key flag, context code,
-            previous key - state flag, and transition - state flag, as shown in the following table.
-            0 - 15
-            Specifies the repeat count for the current message.The value is the number of times the keystroke is
-            autorepeated as a result of the user holding down the key.
-            The repeat count is always one for a WM_KEYUP message.
-            16 - 23
-            Specifies the scan code.The value depends on the OEM.
-            24
-            Specifies whether the key is an extended key, such as the right - hand ALT and CTRL keys that
-            appear on an enhanced 101 - or 102 - key keyboard.The value is 1 if it is an extended key; otherwise, it is
-        0. 25 - 28 Reserved; do not use. 29 Specifies the context code.The value is always 0 for a WM_KEYUP message. 30
-            Specifies the previous key state.The value is always 1 for a WM_KEYUP message.
-            31
-            Specifies the transition state.The value is always 1 for a WM_KEYUP message.*/
-        // ret = ::SendMessageW(_hwnd, WM_KEYUP, vk_code, 0);
-        DWORD dwVKFkeyData;
-        WORD dwScanCode = MapVirtualKey(vk_code, 0);
-        dwVKFkeyData = 1;
-        dwVKFkeyData |= dwScanCode << 16;
-        dwVKFkeyData |= 0 << 24;
-        dwVKFkeyData |= 0 << 29;
-        dwVKFkeyData |= 3 << 30;
-        ret = ::SendMessageTimeout(_hwnd, WM_KEYUP, vk_code, dwVKFkeyData, SMTO_BLOCK, 2000, nullptr);
+        // 抬键时保持和按下阶段一致的消息类型与 lParam 位语义。
+        const bool extended = is_extended_vk(vk_code);
+        const bool use_system_message = is_alt_vk(vk_code) || _alt_down;
+        const bool alt_context = _alt_down && !is_alt_vk(vk_code);
+        const UINT message = use_system_message ? WM_SYSKEYUP : WM_KEYUP;
+        const LPARAM lparam = build_windows_key_lparam(vk_code, true, extended, alt_context);
+
+        ret = ::SendMessageTimeout(_hwnd, message, vk_code, lparam, SMTO_BLOCK, 2000, nullptr);
         if (ret == 0)
             setlog("error code=%d", GetLastError());
+        else {
+            if (is_shift_vk(vk_code))
+                _shift_down = false;
+            else if (is_ctrl_vk(vk_code))
+                _ctrl_down = false;
+            else if (is_alt_vk(vk_code))
+                _alt_down = false;
+        }
         break;
     }
     }
@@ -251,6 +298,13 @@ long winkeypad::KeyPress(long vk_code) {
         break;
     }
     case INPUT_TYPE::IN_WINDOWS: {
+        // 对文本控件补字符消息，便于标准编辑控件直接落字。
+        std::wstring text;
+        if (translate_vk_to_text(vk_code, _shift_down, _ctrl_down, _alt_down, text)) {
+            const UINT char_message = _alt_down ? WM_SYSCHAR : WM_CHAR;
+            for (wchar_t ch : text)
+                ::SendMessageTimeout(_hwnd, char_message, ch, 1, SMTO_BLOCK, 2000, nullptr);
+        }
         ::Delay(KEYPAD_WINDOWS_DELAY);
         break;
     }

--- a/libop/background/keypad/winkeypad.h
+++ b/libop/background/keypad/winkeypad.h
@@ -23,5 +23,10 @@ class winkeypad : public bkkeypad {
     virtual long WaitKey(long vk_code, unsigned long time_out);
 
     virtual long KeyPress(long vk_code);
+
+  private:
+    bool _shift_down = false;
+    bool _ctrl_down = false;
+    bool _alt_down = false;
 };
 #endif // !_WIN_KEYPAD_H_

--- a/libop/libop.cpp
+++ b/libop/libop.cpp
@@ -166,7 +166,7 @@ libop::libop() : m_context(std::make_unique<op_context>()) {
     _vkmap[L"win"] = VK_LWIN;
     _vkmap[L"lwin"] = VK_LWIN;
     _vkmap[L"rwin"] = VK_RWIN;
-    _vkmap[L"space"] = L' ';
+    _vkmap[L"space"] = VK_SPACE;
     _vkmap[L"cap"] = VK_CAPITAL;
     _vkmap[L"tab"] = VK_TAB;
     _vkmap[L"esc"] = VK_ESCAPE;
@@ -820,7 +820,8 @@ void libop::KeyPressStr(const wchar_t *key_str, long delay, long *ret) {
         *ret = key_combo_press(m_context->bkproc._keypad, combo);
         if (*ret == 0)
             return;
-        ::Delay(delay);
+        // 连续输入时给控件留一点处理时间，避免字符连发被吞掉。
+        ::Delay(delay > 0 ? delay : 1);
     }
 }
 

--- a/libop/libop.cpp
+++ b/libop/libop.cpp
@@ -18,6 +18,7 @@
 #include <filesystem>
 #include <fstream>
 #include <regex>
+#include <vector>
 
 #undef FindWindow
 #undef FindWindowEx
@@ -28,6 +29,98 @@ const int small_block_size = 10;
 std::atomic<int> libop::s_id(0);
 const int SC_DATA_TOP = 0;
 const int SC_DATA_BOTTOM = 1;
+
+namespace {
+
+struct key_combo_t {
+    long vk = 0;
+    std::vector<long> modifiers;
+};
+
+// 先按名称键查表，例如 ctrl、enter、f1。
+bool is_named_vk(const std::map<std::wstring, long> &vkmap, const wchar_t *text, long &vk) {
+    if (text == nullptr || text[0] == L'\0')
+        return false;
+
+    std::wstring key = text;
+    wstring2lower(key);
+    auto it = vkmap.find(key);
+    if (it == vkmap.end())
+        return false;
+
+    vk = it->second;
+    return true;
+}
+
+// 把单个字符拆成“主键 + 修饰键”组合。
+bool resolve_char_key_combo(const wchar_t ch, key_combo_t &combo) {
+    const SHORT mapped = ::VkKeyScanW(ch);
+    if (mapped == -1)
+        return false;
+
+    combo = {};
+    combo.vk = LOBYTE(mapped);
+
+    const BYTE shift_state = HIBYTE(mapped);
+    if (shift_state & 1)
+        combo.modifiers.push_back(VK_SHIFT);
+    if (shift_state & 2)
+        combo.modifiers.push_back(VK_CONTROL);
+    if (shift_state & 4)
+        combo.modifiers.push_back(VK_MENU);
+
+    return combo.vk != 0;
+}
+
+// 统一解析字符串按键，优先支持命名键，其次支持单字符。
+bool resolve_text_key_combo(const std::map<std::wstring, long> &vkmap, const wchar_t *text, key_combo_t &combo) {
+    long named_vk = 0;
+    if (is_named_vk(vkmap, text, named_vk)) {
+        combo = {};
+        combo.vk = named_vk;
+        return true;
+    }
+
+    if (text == nullptr || text[0] == L'\0' || text[1] != L'\0')
+        return false;
+
+    return resolve_char_key_combo(text[0], combo);
+}
+
+long key_combo_down(bkkeypad *keypad, const key_combo_t &combo) {
+    // 先按修饰键，再按主键。
+    for (long modifier : combo.modifiers) {
+        if (keypad->KeyDown(modifier) != 1)
+            return 0;
+    }
+    return keypad->KeyDown(combo.vk);
+}
+
+long key_combo_up(bkkeypad *keypad, const key_combo_t &combo) {
+    long ret = keypad->KeyUp(combo.vk);
+    if (ret != 1)
+        return ret;
+
+    // 抬键时反向释放修饰键。
+    for (auto it = combo.modifiers.rbegin(); it != combo.modifiers.rend(); ++it) {
+        if (keypad->KeyUp(*it) != 1)
+            return 0;
+    }
+    return 1;
+}
+
+// 一次性完成组合键按下和释放。
+long key_combo_press(bkkeypad *keypad, const key_combo_t &combo) {
+    // 无修饰键时直接复用原有按键节奏，避免改变不同模式的时序。
+    if (combo.modifiers.empty())
+        return keypad->KeyPress(combo.vk);
+
+    if (key_combo_down(keypad, combo) != 1)
+        return 0;
+    return key_combo_up(keypad, combo);
+}
+
+} // namespace
 // using bytearray = std::vector<unsigned char>;
 struct op_context {
     // 1. Windows API
@@ -62,21 +155,32 @@ libop::libop() : m_context(std::make_unique<op_context>()) {
     std::map<std::wstring, long> &_vkmap = m_context->vkmap;
     _vkmap[L"back"] = VK_BACK;
     _vkmap[L"ctrl"] = VK_CONTROL;
-    _vkmap[L"alt"] = 18;
+    _vkmap[L"lctrl"] = VK_LCONTROL;
+    _vkmap[L"rctrl"] = VK_RCONTROL;
+    _vkmap[L"alt"] = VK_MENU;
+    _vkmap[L"lalt"] = VK_LMENU;
+    _vkmap[L"ralt"] = VK_RMENU;
     _vkmap[L"shift"] = VK_SHIFT;
+    _vkmap[L"lshift"] = VK_LSHIFT;
+    _vkmap[L"rshift"] = VK_RSHIFT;
     _vkmap[L"win"] = VK_LWIN;
+    _vkmap[L"lwin"] = VK_LWIN;
+    _vkmap[L"rwin"] = VK_RWIN;
     _vkmap[L"space"] = L' ';
     _vkmap[L"cap"] = VK_CAPITAL;
     _vkmap[L"tab"] = VK_TAB;
     _vkmap[L"esc"] = VK_ESCAPE;
-    _vkmap[L"enter"] = L'\r';
+    _vkmap[L"enter"] = VK_RETURN;
     _vkmap[L"up"] = VK_UP;
     _vkmap[L"down"] = VK_DOWN;
     _vkmap[L"left"] = VK_LEFT;
     _vkmap[L"right"] = VK_RIGHT;
-    _vkmap[L"option"] = VK_APPS;
+    _vkmap[L"menu"] = VK_APPS;
     _vkmap[L"print"] = VK_SNAPSHOT;
+    _vkmap[L"insert"] = VK_INSERT;
     _vkmap[L"delete"] = VK_DELETE;
+    _vkmap[L"pause"] = VK_PAUSE;
+    _vkmap[L"scroll"] = VK_SCROLL;
     _vkmap[L"home"] = VK_HOME;
     _vkmap[L"end"] = VK_END;
     _vkmap[L"pgup"] = VK_PRIOR;
@@ -654,14 +758,10 @@ void libop::KeyDown(long vk_code, long *ret) {
 }
 
 void libop::KeyDownChar(const wchar_t *vk_code, long *ret) {
-    auto nlen = wcslen(vk_code);
     *ret = 0;
-    if (nlen > 0) {
-        wstring s = vk_code;
-        wstring2lower(s);
-        long vk = m_context->vkmap.count(s) ? m_context->vkmap[s] : ::toupper(vk_code[0]);
-        *ret = m_context->bkproc._keypad->KeyDown(vk);
-    }
+    key_combo_t combo;
+    if (resolve_text_key_combo(m_context->vkmap, vk_code, combo))
+        *ret = key_combo_down(m_context->bkproc._keypad, combo);
 }
 
 void libop::KeyUp(long vk_code, long *ret) {
@@ -669,14 +769,10 @@ void libop::KeyUp(long vk_code, long *ret) {
 }
 
 void libop::KeyUpChar(const wchar_t *vk_code, long *ret) {
-    auto nlen = wcslen(vk_code);
     *ret = 0;
-    if (nlen > 0) {
-        wstring s = vk_code;
-        wstring2lower(s);
-        long vk = m_context->vkmap.count(s) ? m_context->vkmap[s] : ::toupper(vk_code[0]);
-        *ret = m_context->bkproc._keypad->KeyUp(vk);
-    }
+    key_combo_t combo;
+    if (resolve_text_key_combo(m_context->vkmap, vk_code, combo))
+        *ret = key_combo_up(m_context->bkproc._keypad, combo);
 }
 
 void libop::WaitKey(long vk_code, long time_out, long *ret) {
@@ -690,15 +786,10 @@ void libop::KeyPress(long vk_code, long *ret) {
 }
 
 void libop::KeyPressChar(const wchar_t *vk_code, long *ret) {
-    auto nlen = wcslen(vk_code);
     *ret = 0;
-    if (nlen > 0) {
-        // setlog(vk_code);
-        wstring s = vk_code;
-        wstring2lower(s);
-        long vk = m_context->vkmap.count(s) ? m_context->vkmap[s] : ::toupper(vk_code[0]);
-        *ret = m_context->bkproc._keypad->KeyPress(vk);
-    }
+    key_combo_t combo;
+    if (resolve_text_key_combo(m_context->vkmap, vk_code, combo))
+        *ret = key_combo_press(m_context->bkproc._keypad, combo);
 }
 
 void libop::SetKeypadDelay(const wchar_t *type, long delay, long *ret) {
@@ -708,7 +799,7 @@ void libop::SetKeypadDelay(const wchar_t *type, long delay, long *ret) {
     *ret = 1;
     if (wcscmp(type, L"normal") == 0)
         KEYPAD_NORMAL_DELAY = delay;
-    else if (wcscmp(type, L"normal2") == 0)
+    else if (wcscmp(type, L"normal.hd") == 0)
         KEYPAD_NORMAL2_DELAY = delay;
     else if (wcscmp(type, L"windows") == 0)
         KEYPAD_WINDOWS_DELAY = delay;
@@ -722,8 +813,11 @@ void libop::KeyPressStr(const wchar_t *key_str, long delay, long *ret) {
     *ret = 0;
     auto nlen = wcslen(key_str);
     for (size_t i = 0; i < nlen; ++i) {
-        long vkCode = ::VkKeyScanW(key_str[i]);
-        *ret = m_context->bkproc._keypad->KeyPress(vkCode);
+        key_combo_t combo;
+        if (!resolve_char_key_combo(key_str[i], combo))
+            return;
+
+        *ret = key_combo_press(m_context->bkproc._keypad, combo);
         if (*ret == 0)
             return;
         ::Delay(delay);


### PR DESCRIPTION
## 说明

修复 `keypad` 在 `normal`、`normal.hd`、`windows` 模式下的键盘输入问题。

## 主要修改

- 修复字符按键映射，支持大写字母和符号输入
- 支持 `SetKeypadDelay("normal.hd")`
- 修复 `windows` 模式下的按键消息和字符消息处理
- 修复 `normal.hd` 扩展键输入标志
- 整理常用虚拟按键映射

## 验证

- 已完成 `keypad` 相关测试
- 已验证输入：
  - `KeyPressStr("abc", 100)`
  - `KeyPressStr("A!", 100)`